### PR TITLE
Reworked swerve drive teleop to be decoupled from odometry.

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -116,6 +116,8 @@ public class Robot extends TimedRobot
         teleopLights.active = true;
         autonLights.active = false;
         disabledLights.state = LightState.kDisabledError;
+
+        mRobotContainer.resetHeadingToAlliance();
     }
 
     // Run continuously when the robot is in teleop mode.

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -342,4 +342,12 @@ public class RobotContainer
     {
         return autoChooser.getSelected();
     }
+
+    /**
+     * Used to establish field oriented control to the correct alliance side
+     */
+    public void resetHeadingToAlliance() {
+        mSwerveTeleop.resetHeadingToAlliance();
+    }
+
 }

--- a/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -126,19 +126,13 @@ public class SwerveSubsystem extends SubsystemBase
     }
 
     // Drive in some direction with its reference point set to the field itself.
-    public void driveFieldOriented(ChassisSpeeds pVelocity)
+    public void driveFieldOriented(ChassisSpeeds pVelocity, double pFieldHeadingDegrees)
     {
-        if (Robot.isRedAlliance())
-        {
-            ChassisSpeeds fieldOrientedVelocity = ChassisSpeeds.fromFieldRelativeSpeeds(
-                    pVelocity,
-                    mSwerveDrive.getYaw().plus(Rotation2d.fromRadians(Math.PI)));
+        ChassisSpeeds fieldOrientedVelocity =
+            ChassisSpeeds.fromFieldRelativeSpeeds(
+                pVelocity,
+                Rotation2d.fromDegrees(getGyroDegrees()).minus(Rotation2d.fromDegrees(pFieldHeadingDegrees)));
             mSwerveDrive.drive(fieldOrientedVelocity);
-        }
-        else
-        {
-            mSwerveDrive.driveFieldOriented(pVelocity);
-        }
     }
 
     public void driveRobotOriented(ChassisSpeeds pVelocity)
@@ -157,16 +151,6 @@ public class SwerveSubsystem extends SubsystemBase
         mSwerveDrive.resetOdometry(pPose);
     }
 
-    public void resetHeading()
-    {
-        Rotation2d newHeading = Rotation2d.fromRadians(0);
-        if (Robot.isRedAlliance())
-        {
-            newHeading = Rotation2d.fromRadians(Math.PI);
-        }
-        resetOdometry(new Pose2d(getPose().getTranslation(), newHeading));
-    }
-
     public Pose2d getPose()
     {
         return mSwerveDrive.getPose();
@@ -175,6 +159,14 @@ public class SwerveSubsystem extends SubsystemBase
     public double getHeadingDegrees()
     {
         return mSwerveDrive.getPose().getRotation().getDegrees();
+    }
+
+    /**
+     * @return The current heading read from the gyroscope in degrees
+     */
+    public double getGyroDegrees() {
+        double gyroReading = Rotation2d.fromRadians(mSwerveDrive.getGyro().getRotation3d().getZ()).getDegrees();
+        return ((gyroReading % 360) + 360) % 360;
     }
 
     public ChassisSpeeds getRobotRelativeSpeeds()


### PR DESCRIPTION
The purpose of this commit is to decouple the swerve drive controls from the odometry data as systems such as vision could update it and cause it behave erratically. These controls now only rely gyro out puts apart from teleop establishing the initial correct field oriented heading.